### PR TITLE
This commit fixes the incorrect GitHub marker link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,6 @@ We acknowledge the following people for their dedications to make this project a
 | Name | GitHub | Social |
 |------|--------|--------|
 | Gregory Bowne | [@gbowne1](https://github.com/gbowne1) | <https://www.twitter/gbowne1/> |
-| Deepak Sing | [@gbowne1](https://github.com/k-deepak04) |  |
-| Giri Madhan | [@gbowne1](https://github.com/giri-madhan) |  |
-| Tanuj Sengupta | [@gbowne1](https://github.com/Yuva0) |  |
+| Deepak Sing | [@k-deepak04](https://github.com/k-deepak04) |  |
+| Giri Madhan | [@giri-madhan](https://github.com/giri-madhan) |  |
+| Tanuj Sengupta | [@Yuva0](https://github.com/Yuva0) |  |


### PR DESCRIPTION
Fixed incorrect Markdown headers for the table in the CONTRIBUTORS.md file links from the last PR.

