### PR TITLE
#14 added categories to SideNav and Table

### DIFF
--- a/src/components/Library/Library.jsx
+++ b/src/components/Library/Library.jsx
@@ -232,6 +232,7 @@ export default function Library() {
               <TableCell>Action</TableCell>
               <TableCell>Title</TableCell>
               <TableCell align="center">Author</TableCell>
+              <TableCell align="center">Category</TableCell>
               <TableCell align="center">Publisher</TableCell>
               <TableCell align="center">ISBN</TableCell>
               <TableCell align="center">Year</TableCell>
@@ -268,6 +269,7 @@ export default function Library() {
                   {row.name}
                 </TableCell>
                 <TableCell align="center">{row.author}</TableCell>
+                <TableCell align="center">{row.category}</TableCell>
                 <TableCell align="center">{row.publisher}</TableCell>
                 <TableCell align="center">{row.isbn}</TableCell>
                 <TableCell align="center">{row.year}</TableCell>

--- a/src/components/SideNav/SideNav.jsx
+++ b/src/components/SideNav/SideNav.jsx
@@ -16,21 +16,28 @@ import SchoolIcon from "@mui/icons-material/School";
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
 import PsychologyIcon from "@mui/icons-material/Psychology";
+import WebIcon from "@mui/icons-material/Web";
+import LayersIcon from "@mui/icons-material/Layers";
+import DesignServicesIcon from "@mui/icons-material/DesignServices";
+import CodeIcon from "@mui/icons-material/Code";
+import DataObjectIcon from "@mui/icons-material/DataObject";
+import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
+import BugReportIcon from "@mui/icons-material/BugReport";
 
 export default function SideNav() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isItemExpanded, setIsItemExpanded] = useState({});
 
-  const expandItem = (label) => {
-    setIsItemExpanded({ ...isItemExpanded, [label]: !isItemExpanded[label] });
+  const expandItem = (name) => {
+    setIsItemExpanded({ ...isItemExpanded, [name]: !isItemExpanded[name] });
   };
 
-  const MenuButton = ({ buttonProps, label, icon, expandable }) => (
+  const MenuButton = ({ buttonProps, name, label, icon, expandable }) => (
     <ListItemButton
       {...buttonProps}
       onClick={() => {
         buttonProps.onClick?.();
-        expandable && expandItem(label);
+        expandable && expandItem(name);
       }}
     >
       <ListItemIcon>{icon}</ListItemIcon>
@@ -51,7 +58,7 @@ export default function SideNav() {
           setIsDrawerOpen(true);
         }}
       >
-        <MenuIcon  />
+        <MenuIcon />
       </IconButton>
       <Drawer
         anchor="left"
@@ -68,6 +75,7 @@ export default function SideNav() {
                 component: "a",
               }}
               label="Library"
+              name="library"
               icon={<BookIcon />}
             />
             <MenuButton
@@ -76,20 +84,100 @@ export default function SideNav() {
                 component: "a",
               }}
               label="Category"
+              name="category"
               expandable
               icon={<CategoryIcon />}
             />
-            <Collapse in={isItemExpanded.Category} timeout="auto" unmountOnExit>
+            <Collapse in={isItemExpanded.category} timeout="auto" unmountOnExit>
               <List component="div" disablePadding>
                 <MenuButton
                   buttonProps={{ sx: { pl: 4 } }}
                   label="Educational"
+                  name="educational"
                   icon={<SchoolIcon />}
                 />
                 <MenuButton
                   buttonProps={{ sx: { pl: 4 } }}
                   label="Psychology"
+                  name="psychology"
                   icon={<PsychologyIcon />}
+                />
+                <MenuButton
+                  buttonProps={{ sx: { pl: 4 } }}
+                  label="Web Development"
+                  name="webdev"
+                  expandable
+                  icon={<WebIcon />}
+                />
+                <Collapse
+                  in={isItemExpanded.webdev}
+                  timeout="auto"
+                  unmountOnExit
+                >
+                  <List component="div" disablePadding>
+                    <MenuButton
+                      buttonProps={{ sx: { pl: 7 } }}
+                      label="HTML, CSS, JavaScript, etc."
+                      name="webstack"
+                      icon={<LayersIcon />}
+                    />
+                    <MenuButton
+                      buttonProps={{ sx: { pl: 7 } }}
+                      label="Web Design"
+                      name="webdesign"
+                      icon={<DesignServicesIcon />}
+                    />
+                  </List>
+                </Collapse>
+                <MenuButton
+                  buttonProps={{ sx: { pl: 4 } }}
+                  label="Languages"
+                  name="languages"
+                  expandable
+                  icon={<DataObjectIcon />}
+                />
+                <Collapse
+                  in={isItemExpanded.languages}
+                  timeout="auto"
+                  unmountOnExit
+                >
+                  <List component="div" disablePadding>
+                    <MenuButton
+                      buttonProps={{ sx: { pl: 7 } }}
+                      label="Python, C, C++, Assembly, C#, JavaScript, Perl, PHP, Typescript, etc."
+                      name="languagelist"
+                      icon={<CodeIcon />}
+                    />
+                  </List>
+                </Collapse>
+                <MenuButton
+                  buttonProps={{ sx: { pl: 4 } }}
+                  label="Frameworks & Libraries"
+                  name="libs"
+                  expandable
+                  icon={<LibraryBooksIcon />}
+                />
+                <Collapse in={isItemExpanded.libs} timeout="auto" unmountOnExit>
+                  <List component="div" disablePadding>
+                    <MenuButton
+                      buttonProps={{ sx: { pl: 7 } }}
+                      label="React, Angular, Vue, Next, Nuxt, etc."
+                      name="frontlibs"
+                      icon={<CodeIcon />}
+                    />
+                    <MenuButton
+                      buttonProps={{ sx: { pl: 7 } }}
+                      label="Microsoft, i.e, .NET, Azure"
+                      name="backlibs"
+                      icon={<CodeIcon />}
+                    />
+                  </List>
+                </Collapse>
+                <MenuButton
+                  buttonProps={{ sx: { pl: 4 } }}
+                  label="Agile/QA/Testing"
+                  name="testing"
+                  icon={<BugReportIcon />}
                 />
               </List>
             </Collapse>


### PR DESCRIPTION
Added the following categories to SideNav and Category column on the table:

![image](https://user-images.githubusercontent.com/43295849/232908206-b234c2dd-1734-43ac-ae09-08d44fa4b7b7.png)

Expanded categories:
![image](https://user-images.githubusercontent.com/43295849/232908385-60c88a87-3e8e-4ee7-99b9-eb578b3a42aa.png)

Not sure what's the scope for this issue, but this can stablish a base to add further categories or split them. Also adding the actual categories to the mocked data.
