### PR TITLE
Changed variant to 'p' from 'h6'

### DIFF
--- a/src/components/Library/Library.jsx
+++ b/src/components/Library/Library.jsx
@@ -391,7 +391,7 @@ export default function Library({filter}) {
 									);
 								})
 							) : (
-								<Typography variant='h6'>
+								<Typography variant='p'>
 									There are no reviews yet for <strong>{book?.name}</strong>
 								</Typography>
 							)}


### PR DESCRIPTION
Closes #69 

Changed variant in Typography component to 'p' from 'h6'.