### PR TITLE
Fix bug: Category field wrongly populates 'Author' column in book addition form

### DIFF
--- a/src/components/Library/Library.jsx
+++ b/src/components/Library/Library.jsx
@@ -55,6 +55,7 @@ export default function Library({ filter }) {
     const [showModal, handleModalBox] = useState(false);
     const [name, setName] = useState('');
     const [author, setAuthor] = useState('');
+    const [category, setCategory] = useState('');
     const [publisher, setPublisher] = useState('');
     const [isbn, setIsbn] = useState('');
     const [year, setYear] = useState('');
@@ -84,10 +85,19 @@ export default function Library({ filter }) {
     };
     const addItemToTable = (e) => {
         e.preventDefault();
-        if (name && author && publisher && isbn && year && edition) {
+        if (
+            name &&
+            author &&
+            category &&
+            publisher &&
+            isbn &&
+            year &&
+            edition
+        ) {
             let bookObj = {
                 name,
                 author,
+                category,
                 publisher,
                 isbn,
                 year,
@@ -102,12 +112,13 @@ export default function Library({ filter }) {
         } else {
             setBlankEntry(true);
         }
-        console.log(name, author, publisher, isbn, year, edition);
+        console.log(name, author, category, publisher, isbn, year, edition);
     };
 
     const resetBookState = () => {
         setName('');
         setAuthor('');
+        setCategory('');
         setPublisher('');
         setIsbn('');
         setYear('');
@@ -437,7 +448,7 @@ export default function Library({ filter }) {
                         <TextField
                             label='Enter Category'
                             onChange={(e) => {
-                                setAuthor(e.target.value);
+                                setCategory(e.target.value);
                             }}
                             fullWidth
                             style={{ marginTop: '10px' }}


### PR DESCRIPTION
This PR addresses an issue opened by @gbowne1 where entering a book with a specified category, such as "Web Development," resulted in the category being displayed in the "Author" column instead of the intended "Category" column on the book addition form. The PR corrects this issue and ensures that the category is correctly displayed in the "Category" column as intended.

REASON FOR THIS BUG

I. A state for the category was missing (all book properties had corresponding states except for the category).

II. Since there wasn't a category state, the addItemToTable function doesn't verify if the category field contains an entry, unlike the other fields that it validates.

III. Consequently, the bookObj object variable does not incorporate a category entry (despite accepting other fields). Therefore, when this modified bookObj is merged into the myBooks array, the absence of a category entry becomes evident. Consequently, even though the UI component for the category field is present, the data returned lacks a category entry, leading to its absence in the display.

IV. At line 440 of the Library.js component, the text field meant for inputting the category is using the 'setAuthor' state to set its value, even though there was no 'setCategory' state available. As a result, when a book is added under this circumstance, the category value gets placed in the author field, and the category entry is unintentionally omitted.

STEPS TAKEN TO RESOLVE THIS ISSUE

- Added a 'category' state using the useState hook in the Library.js component.

- Updated the text field for the category input to use the 'setCategory' state for setting its value.

- Updated the 'addItemToTable' function to properly check and include the category entry in the 'bookObj'.