### PR TITLE
Feat/add tailwindcss on top of mui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
                 "eslint-config-react-app": "^7.0.1",
                 "eslint-plugin-prettier": "^5.0.0",
                 "eslint-plugin-react": "^7.33.0",
-                "prettier": "^3.0.0"
+                "prettier": "^3.0.0",
+                "tailwindcss": "^3.3.3"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -16607,9 +16608,9 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.2.tgz",
-            "integrity": "sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
+            "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -16631,7 +16632,6 @@
                 "postcss-load-config": "^4.0.1",
                 "postcss-nested": "^6.0.1",
                 "postcss-selector-parser": "^6.0.11",
-                "postcss-value-parser": "^4.2.0",
                 "resolve": "^1.22.2",
                 "sucrase": "^3.32.0"
             },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "eslint-config-react-app": "^7.0.1",
         "eslint-plugin-prettier": "^5.0.0",
         "eslint-plugin-react": "^7.33.0",
-        "prettier": "^3.0.0"
+        "prettier": "^3.0.0",
+        "tailwindcss": "^3.3.3"
     }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/components/BookSearch/BookSearch.css
+++ b/src/components/BookSearch/BookSearch.css
@@ -16,12 +16,14 @@
     margin-right: 10px;
     letter-spacing: 0.5px;
 
-    &:focus,
-    &:active,
-    &:hover {
-        box-shadow: 2px 4px 16px rgba(28, 32, 36, 0.6);
-    }
+   
 }
+.search-input:focus,
+.search-input:active,
+.search-input:hover {
+    box-shadow: 2px 4px 16px rgba(28, 32, 36, 0.6);
+}
+
 
 .search-input:focus {
     outline: none;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@tailwind components;
+@tailwind utilities;
+
 body {
     margin: 0;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { StyledEngineProvider } from '@mui/styled-engine';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
     <React.StrictMode>
-        <App />
+        <StyledEngineProvider injectFirst>
+            <App />
+        </StyledEngineProvider>
     </React.StrictMode>
 );
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+  ],
+  important: "#root",
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This PR introduces the integration of TailwindCSS alongside Material-UI version 5 (MUI v5) in our project.

### Changes Made
- Added TailwindCSS as a CSS utility framework.
- Removed nested styles from BookSearch.css to address Tailwind nesting style error.