### PR TITLE
Fix/css: Remove font-smooth styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,6 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
         'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
         'Helvetica Neue', sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 code {


### PR DESCRIPTION
closes #185 
Since Firefox supports box-shadow so well, it has no reason to keep -moz-box-shadow around. It dropped support for the prefix in version 13
Also font-smooth styling is not recommended for production.
ref: https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth