### PR TITLE
 Add Reusable Custom Axios Hook for HTTP Requests 

### DIFF
--- a/src/hooks/useAxios.js
+++ b/src/hooks/useAxios.js
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import axios from 'axios';
+
+const useAxios = (
+    config,
+    initialState = { response: null, error: null, loading: true }
+) => {
+    const [response, setResponse] = useState(initialState.response);
+    const [error, setError] = useState(initialState.error);
+    const [loading, setLoading] = useState(initialState.loading);
+
+    // Use useMemo to avoid unnecessary reruns
+    const axiosConfig = useMemo(
+        () => ({
+            ...config,
+        }),
+        [config]
+    );
+
+    const fetchData = useCallback(async () => {
+        setLoading(true);
+        try {
+            const result = await axios(axiosConfig);
+            setResponse(result.data);
+            setError(null);
+        } catch (err) {
+            setError(err.message);
+            setResponse(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [axiosConfig]);
+
+    useEffect(() => {
+        const source = axios.CancelToken.source();
+        axiosConfig.cancelToken = source.token;
+
+        fetchData();
+
+        // Cancel the request if component unmounts
+        return () => source.cancel('Axios request canceled.');
+    }, [fetchData, axiosConfig]);
+
+    return { response, error, loading, refetch: fetchData };
+};
+
+export default useAxios;
+
+/* Examples of usage */
+
+// Example Usage for a POST Request
+// function PostCommentForm() {
+//     const [comment, setComment] = useState('');
+//     const { response, error, loading, refetch } = useAxios({
+//         url: '/api/comments',
+//         method: 'post',
+//         data: { comment },
+//     }, { loading: false }); // Prevents automatic fetching
+
+//     const handleSubmit = (e) => {
+//         e.preventDefault();
+//         refetch(); // Trigger the POST request manually
+//     };
+
+//     return (
+//         <form onSubmit={handleSubmit}>
+//             <textarea value={comment} onChange={(e) => setComment(e.target.value)} />
+//             <button type="submit">Submit Comment</button>
+//             {loading && <p>Submitting...</p>}
+//             {error && <p>Error: {error}</p>}
+//             {response && <p>Comment submitted successfully!</p>}
+//         </form>
+//     );
+// }
+
+// Example Usage for a GET Request with dynamic params
+// function UserDetails({ userId }) {
+//     const { response, error, loading, refetch } = useAxios({
+//         url: `/api/users/${userId}`,
+//         method: 'get',
+//     }, { loading: false }); // Initially prevents fetching
+
+//     useEffect(() => {
+//         if (userId) {
+//             refetch(); // Refetch user details when userId changes
+//         }
+//     }, [userId, refetch]);
+
+//     if (loading) return <p>Loading user details...</p>;
+//     if (error) return <p>Error fetching user details: {error}</p>;
+
+//     return (
+//         <div>
+//             <h3>User Details</h3>
+//             <p>Name: {response?.name}</p>
+//             <p>Email: {response?.email}</p>
+//         </div>
+//     );
+// }


### PR DESCRIPTION
@gbowne1 

## Overview
This PR introduces a new reusable custom Axios hook, `useAxios`, aimed at simplifying HTTP requests across the application. It strives for a balance between simplicity and functionality, making HTTP calls more straightforward and maintainable.

## Changes
- Added `useAxios.js` implementing the custom Axios hook.
- Included two examples demonstrating the hook's usage for both a GET request and a POST request.

## Details
The `useAxios` hook provides an easy-to-use interface for making HTTP requests while handling loading states, errors, and data responses efficiently. It is designed to be flexible for various use cases, supporting different HTTP methods and configurations.

### Example Usage
1. **GET Request Example**: Fetches data from an endpoint and handles loading and errors.
2. **POST Request Example**: Demonstrates sending data to an endpoint and handling responses.

## Goal
The goal of this PR is to enhance the codebase with a tool that abstracts away the complexities of making HTTP requests, thereby improving code readability and reducing redundancy.

## Request for Feedback
I welcome any feedback on the balance of simplicity and functionality, as well as the clarity of the included examples. 


Related to issue #218
